### PR TITLE
Re-export structopt to use internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickrs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Kyle Szela <kszela24@gmail.com>", "others"]
 description = "Simplified CLIs for Rust via procedural macros (Python's click, for Rust)."

--- a/clickrs_proc_macro/Cargo.toml
+++ b/clickrs_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickrs_proc_macro"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Kyle Szela <kszela24@gmail.com>"]
 description = "Simplified CLIs for Rust via procedural macros (Python's click, for Rust). The procedural macro crate."

--- a/clickrs_proc_macro/src/lib.rs
+++ b/clickrs_proc_macro/src/lib.rs
@@ -55,7 +55,7 @@ fn build_structopt_block(
     // Define the full tokenstream for the StructOpt struct which includes all the fields we've
     //  collected from above.
     let structopt_block = quote! {
-        use structopt::StructOpt;
+        use clickrs::structopt::StructOpt;
 
         #[derive(Debug, StructOpt)]
         #[structopt(#command_args)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,3 +86,6 @@ ARGS:
 !*/
 
 pub use clickrs_proc_macro::command;
+
+/// Re-exports
+pub use structopt;


### PR DESCRIPTION
* Fixed bug with the way this was getting called.
* Added structopt re-export.